### PR TITLE
Use encoder capabilities for determining screen recording size

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
+++ b/packages/SystemUI/src/com/android/systemui/screenrecord/ScreenMediaRecorder.java
@@ -267,11 +267,13 @@ public class ScreenMediaRecorder extends MediaProjection.Callback {
             throws IOException {
         String videoType = MediaFormat.MIMETYPE_VIDEO_AVC;
 
-        // Get max size from the decoder, to ensure recordings will be playable on device
-        MediaCodec decoder = MediaCodec.createDecoderByType(videoType);
-        MediaCodecInfo.VideoCapabilities vc = decoder.getCodecInfo()
+        // Get max size from the encoder,
+        // implicitly decoder supports this size and
+        // ensure recordings will be playable on device
+        MediaCodec encoder = MediaCodec.createEncoderByType(videoType);
+        MediaCodecInfo.VideoCapabilities vc = encoder.getCodecInfo()
                 .getCapabilitiesForType(videoType).getVideoCapabilities();
-        decoder.release();
+        encoder.release();
 
         // Check if we can support screen size as-is
         int width = vc.getSupportedWidths().getUpper();


### PR DESCRIPTION
Using decoder capabilities for determining max size and rate can cause failure during screen record as encoder might not be capable of supporting it. As encoder supported size and rate are implicitly supported by decoder, recordings will be playable on device.

CRs-Fixed: 3593702
Change-Id: I5c9eb491df248e6150cc956574ab609102db9ac9