### PR TITLE
BootReceiver: Return early if trace_pipe doesn't exists

### DIFF
--- a/services/core/java/com/android/server/BootReceiver.java
+++ b/services/core/java/com/android/server/BootReceiver.java
@@ -145,6 +145,11 @@ public class BootReceiver extends BroadcastReceiver {
     private static final long MAX_TOMBSTONE_SIZE_BYTES =
             DropBoxManagerService.DEFAULT_QUOTA_KB * 1024;
 
+    public boolean fileExists(String fileName) {
+       final File file = new File(fileName);
+        return file.exists();
+    }
+
     @Override
     public void onReceive(final Context context, Intent intent) {
         // Log boot events in the background to avoid blocking the main thread with I/O
@@ -167,6 +172,7 @@ public class BootReceiver extends BroadcastReceiver {
 
         FileDescriptor tracefd = null;
         try {
+            if (!fileExists(ERROR_REPORT_TRACE_PIPE)) return;
             tracefd = Os.open(ERROR_REPORT_TRACE_PIPE, O_RDONLY, 0600);
         } catch (ErrnoException e) {
             Slog.wtf(TAG, "Could not open " + ERROR_REPORT_TRACE_PIPE, e);


### PR DESCRIPTION
* instead of trigerring errnoexception, check if the file or directory exists first , otherwise perform a early return so we can skip the following exception below

12-16 13:05:46.592  1438  1438 E BootReceiver: Could not open /sys/kernel/tracing/instances/bootreceiver/trace_pipe
12-16 13:05:46.592  1438  1438 E BootReceiver: android.system.ErrnoException: open failed: ENOENT (No such file or directory)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at libcore.io.Linux.open(Native Method)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at libcore.io.ForwardingOs.open(ForwardingOs.java:563)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at libcore.io.BlockGuardOs.open(BlockGuardOs.java:274)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.system.Os.open(Os.java:494)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at com.android.server.BootReceiver.onReceive(BootReceiver.java:162)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.app.ActivityThread.handleReceiver(ActivityThread.java:4336)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.app.ActivityThread.-$$Nest$mhandleReceiver(Unknown Source:0)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2154)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.os.Handler.dispatchMessage(Handler.java:106)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.os.Looper.loopOnce(Looper.java:201)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at android.os.Looper.loop(Looper.java:288)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at com.android.server.SystemServer.run(SystemServer.java:982)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at com.android.server.SystemServer.main(SystemServer.java:667)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at java.lang.reflect.Method.invoke(Native Method)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:553)
12-16 13:05:46.592  1438  1438 E BootReceiver: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:924)